### PR TITLE
nox test python 3.10 and 3.11

### DIFF
--- a/ci_tools/nox_utils.py
+++ b/ci_tools/nox_utils.py
@@ -22,7 +22,7 @@ from nox.sessions import Session
 nox_logger = logging.getLogger("nox")
 
 
-PY27, PY35, PY36, PY37, PY38, PY39, PY310 = "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"
+PY27, PY35, PY36, PY37, PY38, PY39, PY310, PY311 = "2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"
 DONT_INSTALL = "dont_install"
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ import sys
 # add parent folder to python path so that we can import noxfile_utils.py
 # note that you need to "pip install -r noxfile-requiterements.txt" for this file to work.
 sys.path.append(str(Path(__file__).parent / "ci_tools"))
-from nox_utils import PY27, PY37, PY36, PY35, PY38, PY39, PY310, power_session, rm_folder, rm_file, PowerSession  # noqa
+from nox_utils import PY27, PY37, PY36, PY35, PY38, PY39, PY310, PY311, power_session, rm_folder, rm_file, PowerSession  # noqa
 
 
 pkg_name = "mkdocs_gallery"
@@ -17,8 +17,8 @@ gh_org = "smarie"
 gh_repo = "mkdocs-gallery"
 
 ENVS = {
-    # python 3.10 is not available on conda yet
-    # PY310: {"coverage": False, "pkg_specs": {"pip": ">19"}},
+    PY311: {"coverage": False, "pkg_specs": {"pip": ">19"}},
+    PY310: {"coverage": False, "pkg_specs": {"pip": ">19"}},
     PY39: {"coverage": False, "pkg_specs": {"pip": ">19"}},
     PY38: {"coverage": False, "pkg_specs": {"pip": ">19"}},
     PY37: {"coverage": True, "pkg_specs": {"pip": ">19"}},  # , "pytest-html": "1.9.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 # one day these will be able to come from requirement files, see https://github.com/pypa/setuptools/issues/1951. But will it be better ?


### PR DESCRIPTION
This is a nice library! I was trying to figure out how to extend it, and found that the nox test matrix does not include python 3.10 & 3.11.

This PR includes python 3.10 and 3.11 in the nox test matrix.

(It might also be a good idea to upgrade the python version used for the "release" "publish" "docs" & "flake8" jobs, since python 3.7 will be at end of life in June. But I haven't changed anything here yet - I want to see if the github actions workflow passes first)