### PR TITLE
Re-raise errors for better ExtensionError messages

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ### 0.7.9 - (In Progress)
 
  - Swapped from deprecated `disutils.version` to `packaging.version`. PR [#79](https://github.com/smarie/mkdocs-gallery/pull/79) by [Samreay](https://github.com/Samreay)
+ - Re-raise errors for better ExtensionError messages, so users have full details about the original problem. PR [#58](https://github.com/smarie/mkdocs-gallery/pull/58) by [GenevieveBuckley](https://github.com/GenevieveBuckley)
 
 ### 0.7.8 - Bugfixes
 

--- a/src/mkdocs_gallery/gen_gallery.py
+++ b/src/mkdocs_gallery/gen_gallery.py
@@ -144,14 +144,14 @@ def load_base_conf(script: Path = None) -> Dict:
         spec = spec_from_file_location("__mkdocs_gallery_conf", script)
         foo = module_from_spec(spec)
         spec.loader.exec_module(foo)
-    except ImportError:
-        raise ExtensionError(f"Error importing base configuration from `base_conf_py` {script}")
+    except ImportError as err_msg:
+        raise ExtensionError(f"Error importing base configuration from `base_conf_py` {script}\n{err_msg}")
 
     try:
         return foo.conf
-    except AttributeError:
+    except AttributeError as err_msg:
         raise ExtensionError(f"Error loading base configuration from `base_conf_py` {script}, module does not contain "
-                             f"a `conf` variable.")
+                             f"a `conf` variable.\n{err_msg}")
 
 
 def _complete_gallery_conf(mkdocs_gallery_conf, mkdocs_conf, lang='python',


### PR DESCRIPTION
This PR takes the string error message that was originally the problem, and includes that information into the ExtensionError message that the user will see. 

Conext: I was getting an ExtensionError from the `load_base_conf` function (in `gen_gallery.py`). Turns out the fix was very simple (just install some extra dependencies), but it was difficult to figure that out since the ExtensionError does not provide much information.

