### PR TITLE
Fix attempt: MySubConfig has no '_pre_validate'

### DIFF
--- a/src/mkdocs_gallery/binder.py
+++ b/src/mkdocs_gallery/binder.py
@@ -205,9 +205,11 @@ def check_binder_conf(binder_conf):
     # Set empty dict if user did not provide any configuration values
     if binder_conf is None:
         binder_conf = {}
-    elif (frozenset(binder_conf.values()) == frozenset()) or \
-         (frozenset(binder_conf.values()) == frozenset([None])) or \
-         (frozenset(binder_conf.values()) == frozenset([None, 'gh-pages', 'https://mybinder.org'])):
+    vals = binder_conf.values()
+    default_values = [None, 'gh-pages', 'https://mybinder.org']
+    if vals == []:
+        binder_conf = {}
+    elif all([val in default_values for val in vals]):
         binder_conf = {}
     # Return an empty dict if it's not configured
     if len(binder_conf) == 0:

--- a/src/mkdocs_gallery/binder.py
+++ b/src/mkdocs_gallery/binder.py
@@ -199,10 +199,17 @@ def _copy_binder_notebooks(gallery_conf, mkdocs_conf):
 def check_binder_conf(binder_conf):
     """Check to make sure that the Binder configuration is correct."""
 
-    # Grab the configuration and return None if it's not configured
-    binder_conf = {} if binder_conf is None else binder_conf
-    if not isinstance(binder_conf, dict):
+    if not isinstance(binder_conf, (dict, None)):
         raise ConfigError('`binder_conf` must be a dictionary or None.')
+
+    # Set empty dict if user did not provide any configuration values
+    if binder_conf is None:
+        binder_conf = {}
+    elif (frozenset(binder_conf.values()) == frozenset()) or \
+         (frozenset(binder_conf.values()) == frozenset([None])) or \
+         (frozenset(binder_conf.values()) == frozenset([None, 'gh-pages', 'https://mybinder.org'])):
+        binder_conf = {}
+    # Return an empty dict if it's not configured
     if len(binder_conf) == 0:
         return binder_conf
 

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -54,30 +54,6 @@ class ConfigList(co.OptionallyRequired):
         return result
 
 
-class MySubConfig(co.SubConfig):
-    """Same as SubConfig except that it will be an empty dict when nothing is provided by user,
-    instead of a dict with all options containing their default values."""
-
-    def validate(self, value):
-        if value is None or len(value) == 0:
-            return None
-        else:
-            return super(MySubConfig, self).validate(value)
-
-    def run_validation(self, value):
-        """Fix SubConfig: errors and warnings were not caught
-
-        See https://github.com/mkdocs/mkdocs/pull/2710
-        """
-        failed, self.warnings = Config.validate(self)
-        if len(failed) > 0:
-            # get the first failing one
-            key, err = failed[0]
-            raise ConfigurationError(f"Sub-option {key!r} configuration error: {err}")
-
-        return self
-
-
 class Dir(co.Dir):
     """mkdocs.config.config_options.Dir replacement: returns a pathlib object instead of a string"""
     def run_validation(self, value):
@@ -122,7 +98,7 @@ class GalleryPlugin(BasePlugin):
         ('expected_failing_examples', ConfigList(File(exists=True))),
         ('thumbnail_size', ConfigList(co.Type(int), single_elt_allowed=False)),
         ('min_reported_time', co.Type(int)),
-        ('binder', MySubConfig(
+        ('binder', co.SubConfig(
             # Required keys
             ('org', co.Type(str, required=True)),
             ('repo', co.Type(str, required=True)),


### PR DESCRIPTION
(maybe) closes https://github.com/smarie/mkdocs-gallery/issues/57

The way [MySubConfig](https://github.com/smarie/mkdocs-gallery/blob/48a96bd32eb036b1ef82b64b4ef79a76c499eea9/src/mkdocs_gallery/plugin.py#L57-L78) is currently implemented is incompatible with mkdocs versions above 1.2.4.  I *think* getting rid of it entirely removes the issue?
* It worked when I made this change and then build the docs with the python version nox made:
    ```
    .nox/tests-3.9/bin/python ../mkdocs/mkdocs/__main__.py build
    .nox/tests-3.9/bin/python ../mkdocs/mkdocs/__main__.py serve
    ``` 
* I still had some problems trying to run `mkdocs build` directly with my own virtual environment. There's probably something wrong with my environment, so it'd be very helpful if you could try this too on your own machine.


It's also not entirely clear to me why the `MySubConfig` class exists. It looks like there are two reasons:
1. So you can return an empty dict instead of default values if no info is provided by the user
    *  The docstring says *"Same as SubConfig except that it will be an empty dict when nothing is provided by user, instead of a dict with all options containing their default values."* [see this commit](https://github.com/smarie/mkdocs-gallery/commit/4c57af1c48f9227cdb756c3ccaab6ba09187ce9c#diff-889a5fa775ee1485761cb332afeb86aaab0b72c551b32835327e53d991103640) (it's a big commit, you have to scroll down to see the relevant part in `plugin.py`). 
    * But I don't know **why** that's important, or what could go wrong if we take it out. Maybe you can weigh in @smarie?
2. There is also a fix compensating for a bug in mkdocs [see this commit](https://github.com/smarie/mkdocs-gallery/commit/e5ca7c7dd461990ec34b72bad0838192265868b0), which you later fixed upstream [here](https://github.com/mkdocs/mkdocs/pull/2710). I think that means we don't need that part here now?