### PR TITLE
Fixed `Plugin 'gallery' option 'binder': Sub-option 'org': Required configuration not provided`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,8 @@
 # Changelog
 
-### 0.7.X - (in progress) Bugfixes
+### 0.7.8 - Bugfixes
 
- - (todo)
+ - Fixed `Plugin 'gallery' option 'binder': Sub-option 'org': Required configuration not provided.`. Fixes [#62](https://github.com/smarie/mkdocs-gallery/issues/62)
  - Support relative path to `mkdocs.yaml` file using `--config-file` option. Fixes [#63](https://github.com/smarie/mkdocs-gallery/issues/63). PR [#64](https://github.com/smarie/mkdocs-gallery/pull/64) by [fgrbr](https://github.com/fgrbr).
 
 ### 0.7.7 - Bugfixes and new python versions

--- a/src/mkdocs_gallery/gen_gallery.py
+++ b/src/mkdocs_gallery/gen_gallery.py
@@ -209,6 +209,9 @@ def _complete_gallery_conf(
     # Check capture_repr
     capture_repr = gallery_conf["capture_repr"]
     supported_reprs = ["__repr__", "__str__", "_repr_html_"]
+    if isinstance(capture_repr, list):
+        # Convert to tuple.
+        gallery_conf["capture_repr"] = capture_repr = tuple(capture_repr)
     if isinstance(capture_repr, tuple):
         for rep in capture_repr:
             if rep not in supported_reprs:

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -92,7 +92,10 @@ if is_mkdocs_14_or_greater:
         use_jupyter_lab = co.Optional(co.Type(bool))  # default is False
 
     def create_binder_config():
-        return co.SubConfig(_BinderOptions)
+        opt = co.SubConfig(_BinderOptions)
+        # Set the default value to None so that it is not (invalid) empty dict anymore. GH#45
+        opt.default = None
+        return opt
 
 else:
     # Use MySubConfig
@@ -168,7 +171,7 @@ class GalleryPlugin(BasePlugin):
         ("expected_failing_examples", ConfigList(File(exists=True))),
         ("thumbnail_size", ConfigList(co.Type(int), single_elt_allowed=False)),
         ("min_reported_time", co.Type(int)),
-        ("binder", create_binder_config()),
+        ("binder", co.Optional(create_binder_config())),
         ("image_scrapers", ConfigList(co.Type(str))),
         ("compress_images", ConfigList(co.Type(str))),
         ("reset_modules", ConfigList(co.Type(str))),
@@ -237,7 +240,7 @@ markdown_extensions:
         # config['theme'].static_templates.add('search.html')
         # config['extra_javascript'].append('search/main.js')
 
-        # Handle our custom class
+        # Handle our custom class - convert to a dict
         if self.config["binder"]:
             self.config["binder"] = dict(self.config["binder"])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,74 @@ gallery_dirs: docs/generated/gallery  # where to save generated gallery
 
     # Load it (this triggers validation and default values according to the plugin config schema)
     plugin = GalleryPlugin()
-    plugin.load_config(mini_config)
+    errors, warnings = plugin.load_config(mini_config)
+
+    assert len(errors) == 0
+    assert len(warnings) == 0
+
+    # Now mimic the on_config event
+    result = plugin.on_config(basic_mkdocs_config)
+
+    # See also https://github.com/mkdocs/mkdocs/blob/master/mkdocs/tests/plugin_tests.py
+    # And https://github.com/mkdocs/mkdocs/blob/master/mkdocs/tests/search_tests.py
+
+    assert isinstance(plugin.config, dict)
+    assert len(plugin.config) > 0
+
+
+REPO_ROOT_DIR = Path(__file__).parent.parent
+
+
+def test_full_conf(basic_mkdocs_config, monkeypatch):
+    """Test that full config can be loaded without problem"""
+
+    monkeypatch.chdir(REPO_ROOT_DIR)
+
+    # Create a mini config
+    full_config = yaml_load("""
+conf_script: docs/gallery_conf.py
+examples_dirs:
+  - docs/examples
+  - docs/tutorials
+  # TODO mayavi_examples
+gallery_dirs:
+  - docs/generated/gallery
+  - docs/generated/tutorials
+  # TODO tutorials and mayavi_examples
+
+backreferences_dir: docs/generated/backreferences
+doc_module: ['mkdocs_gallery', 'numpy']
+# reference_url: {sphinx_gallery: None}
+image_scrapers: matplotlib
+compress_images: ['images', 'thumbnails']
+within_subsection_order: FileNameSortKey
+expected_failing_examples:
+   - docs/examples/no_output/plot_raise.py
+   - docs/examples/no_output/plot_syntaxerror.py
+
+# min_reported_time: min_reported_time,  in conf file
+
+binder:
+  org: smarie
+  repo: mkdocs-gallery
+  branch: gh-pages
+  binderhub_url: https://mybinder.org
+  dependencies: docs/binder_cfg/requirements.txt
+  notebooks_dir: notebooks
+  use_jupyter_lab: True
+show_memory: True
+# junit: foo/junit-results.xml
+capture_repr: ['_repr_html_', '__repr__']
+matplotlib_animations: True
+image_srcset: ['2x']
+""")
+
+    # Load it (this triggers validation and default values according to the plugin config schema)
+    plugin = GalleryPlugin()
+    errors, warnings = plugin.load_config(full_config)
+
+    assert len(errors) == 0
+    assert len(warnings) == 0
 
     # Now mimic the on_config event
     result = plugin.on_config(basic_mkdocs_config)


### PR DESCRIPTION
Fixes #62

Also, fixed the configuration loading test, and added a "full config" loading test