### PR TITLE
Mkdocs gallery and `sys.path`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ### 0.7.9 - (In Progress)
 
  - Swapped from deprecated `disutils.version` to `packaging.version`. PR [#79](https://github.com/smarie/mkdocs-gallery/pull/79) by [Samreay](https://github.com/Samreay)
+ - Re-raise errors for better ExtensionError messages, so users have full details about the original problem. PR [#58](https://github.com/smarie/mkdocs-gallery/pull/58) by [GenevieveBuckley](https://github.com/GenevieveBuckley)
  - `sys.path` modifications now persist accross blocks of an example. `sys.path` is still reset after each example. PR [#82](https://github.com/smarie/mkdocs-gallery/pull/82) by [Louis-Pujol](https://github.com/Louis-Pujol).
 
 ### 0.7.8 - Bugfixes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,7 @@
 ### 0.7.9 - (In Progress)
 
  - Swapped from deprecated `disutils.version` to `packaging.version`. PR [#79](https://github.com/smarie/mkdocs-gallery/pull/79) by [Samreay](https://github.com/Samreay)
+ - Rewrited `gen_single._reset_cwd_syspath` function to let `sys.path` modifications persist accross blocks. PR [#82](https://github.com/smarie/mkdocs-gallery/pull/82) by [Louis-Pujol](https://github.com/Louis-Pujol).
 
 ### 0.7.8 - Bugfixes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 ### 0.7.9 - (In Progress)
 
  - Swapped from deprecated `disutils.version` to `packaging.version`. PR [#79](https://github.com/smarie/mkdocs-gallery/pull/79) by [Samreay](https://github.com/Samreay)
- - Rewrited `gen_single._reset_cwd_syspath` function to let `sys.path` modifications persist accross blocks. PR [#82](https://github.com/smarie/mkdocs-gallery/pull/82) by [Louis-Pujol](https://github.com/Louis-Pujol).
+ - `sys.path` modifications now persist accross blocks of an example. `sys.path` is still reset after each example. PR [#82](https://github.com/smarie/mkdocs-gallery/pull/82) by [Louis-Pujol](https://github.com/Louis-Pujol).
 
 ### 0.7.8 - Bugfixes
 

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -774,6 +774,7 @@ def execute_code_block(compiler, block, script: GalleryScript):
     # created by the example get created in this directory
     os.chdir(src_file.parent)
 
+    # Add the example dir to the path temporarily (will be removed after execution)
     new_path = os.getcwd()
     sys.path.append(new_path)
 

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -729,9 +729,9 @@ def _get_code_output(is_last_expr, script: GalleryScript, logging_tee, images_md
 
 
 def _reset_cwd_syspath(cwd, path_to_remove):
-    """Reset cwd and sys.path."""
-    if new_path in sys.path:
-        sys.path.remove(new_path)
+    """Reset current working directory to `cwd` and remove `path_to_remove` from `sys.path`."""
+    if path_to_remove in sys.path:
+        sys.path.remove(path_to_remove)
     os.chdir(cwd)
 
 

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -728,10 +728,12 @@ def _get_code_output(is_last_expr, script: GalleryScript, logging_tee, images_md
     return code_output
 
 
-def _reset_cwd_syspath(cwd, sys_path):
+def _reset_cwd_syspath(cwd, new_path):
     """Reset cwd and sys.path."""
+    if new_path in sys.path:
+        sys.path.remove(new_path)
     os.chdir(cwd)
-    sys.path = sys_path
+    # sys.path = sys_path
 
 
 def execute_code_block(compiler, block, script: GalleryScript):
@@ -774,7 +776,8 @@ def execute_code_block(compiler, block, script: GalleryScript):
     os.chdir(src_file.parent)
 
     sys_path = copy.deepcopy(sys.path)
-    sys.path.append(os.getcwd())
+    new_path = os.getcwd()
+    sys.path.append(new_path)
 
     # Save figures unless there is a `mkdocs_gallery_defer_figures` flag
     match = re.search(r"^[\ \t]*#\s*mkdocs_gallery_defer_figures[\ \t]*\n?", bcontent, re.MULTILINE)
@@ -818,11 +821,11 @@ def execute_code_block(compiler, block, script: GalleryScript):
         if need_save_figures:
             save_figures(block, script)
     else:
-        _reset_cwd_syspath(cwd, sys_path)
+        _reset_cwd_syspath(cwd, new_path)
 
         code_output = _get_code_output(is_last_expr, script, logging_tee, images_md)
     finally:
-        _reset_cwd_syspath(cwd, sys_path)
+        _reset_cwd_syspath(cwd, new_path)
         logging_tee.restore_std()
 
     # Sanitize ANSI escape characters from MD output

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import traceback
 import warnings
+from copy import deepcopy
 from functools import partial
 from io import StringIO
 from pathlib import Path
@@ -891,6 +892,9 @@ def parse_and_execute(script: GalleryScript, script_blocks):
     # Remember the original argv so that we can put them back after run
     argv_orig = sys.argv[:]
 
+    # Remember the original sys.path so that we can reset it after run
+    sys_path_orig = deepcopy(sys.path)
+
     # Python file is the original one (not the copy for download)
     sys.argv[0] = script.src_py_file.as_posix()
 
@@ -919,6 +923,9 @@ def parse_and_execute(script: GalleryScript, script_blocks):
 
     # Set back the sys argv
     sys.argv = argv_orig
+
+    # Set back the sys path
+    sys.path = sys_path_orig
 
     # Write md5 checksum if the example was meant to run (no-plot shall not cache md5sum) and has built correctly
     script.write_final_md5_file()

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -733,7 +733,6 @@ def _reset_cwd_syspath(cwd, new_path):
     if new_path in sys.path:
         sys.path.remove(new_path)
     os.chdir(cwd)
-    # sys.path = sys_path
 
 
 def execute_code_block(compiler, block, script: GalleryScript):
@@ -775,7 +774,6 @@ def execute_code_block(compiler, block, script: GalleryScript):
     # created by the example get created in this directory
     os.chdir(src_file.parent)
 
-    sys_path = copy.deepcopy(sys.path)
     new_path = os.getcwd()
     sys.path.append(new_path)
 

--- a/src/mkdocs_gallery/gen_single.py
+++ b/src/mkdocs_gallery/gen_single.py
@@ -728,7 +728,7 @@ def _get_code_output(is_last_expr, script: GalleryScript, logging_tee, images_md
     return code_output
 
 
-def _reset_cwd_syspath(cwd, new_path):
+def _reset_cwd_syspath(cwd, path_to_remove):
     """Reset cwd and sys.path."""
     if new_path in sys.path:
         sys.path.remove(new_path)


### PR DESCRIPTION
Hello,

I have a little issue with `sys.path` and `mkdocs-gallery`. I realized that changes to sys.path were not persistent across code blocks. Here is a simple illustration script :

```python
"""
PYTHONPATH
==========
"""

# %%
# Copy python path

import sys
original_path = sys.path.copy()


# %%
# Append path and print new path directories

sys.path.append("/home/mypath")
new_path = sys.path.copy()
for p in new_path:
    if p not in original_path:
        print(p)


# %%
# Print new path directories

path2 = sys.path.copy()
for p in path2:
    if p not in original_path:
        print(p)
```

And the resulting example:
![Capture d’écran du 2023-11-14 15-13-53](https://github.com/smarie/mkdocs-gallery/assets/52413616/68141bf2-e394-4fbf-b2cc-b68351167616)

`sys.path` Were reinitialized between block 2 and block 3 as `/home/mypath` is no longer inside `sys.path`.This behavior comes from this function, which is called between blocks and reset sys.path: 

https://github.com/smarie/mkdocs-gallery/blob/d4c2d7fd7991a590abc2c947a61334b3a56ab9f7/src/mkdocs_gallery/gen_single.py#L731-#L735


This caused me some trouble because I use some libraries that add cache directories to `sys.path`. If I understand correctly the purpose of `_reset_cwd_path`, it is meant to remove cwd from `sys.path`, but it actually removes all new additions.

In this PR, I propose to modify `_reset_cwd_path` in order to remove only the last cwd and do not erase other modifications to `sys.path`. With this new version, my example works as I expected:

![Capture d’écran du 2023-11-14 15-25-39](https://github.com/smarie/mkdocs-gallery/assets/52413616/ecd20afe-8ee7-4207-8e85-5a0fa09aa18e)

Let me know what are your thoughts about this changes.
Many thanks,
Louis
