### PR TITLE
Fix for deprecated github actions set-output command

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: List 'tests' nox sessions and required python versions
         id: set-matrix
-        run: echo "::set-output name=matrix::$(nox -s gha_list -- -s tests -v)"
+        run: echo "matrix=$(nox -s gha_list -- -s tests -v)" >> $GITHUB_OUTPUT
 
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}  # save nox sessions list to outputs


### PR DESCRIPTION
The github actions set-output command is deprecated, and we are seeing warnings in our CI jobs that it will be removed soon. 

I've followed the guide in this blog post to update our script: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

```
Run echo "::set-output name=matrix::$(nox -s gha_list -- -s tests -v)"
nox > Running session gha_list
nox > Session gha_list was successful.
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

