### PR TITLE
Emoji deprecation warning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.10.4 - Bugfixes
+
+- Emoji logic updated. Fixes [#103](https://github.com/smarie/mkdocs-gallery/issues/103).
+
 ### 0.10.3 - Bugfixes
 
 -  Don't use `asyncio.run` for async handling. Fixes [#93](https://github.com/smarie/mkdocs-gallery/issues/93).

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -224,8 +224,8 @@ markdown_extensions:
 
   # to have the download icons in the buttons
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
 
 
 """

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -7,8 +7,9 @@
 The mkdocs plugin entry point
 """
 import os
-from os.path import relpath
+import platform
 import re
+from os.path import relpath
 from pathlib import Path
 from typing import Any, Dict, List, Union
 
@@ -20,6 +21,7 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 from packaging import version
+from packaging.version import parse as parse_version
 
 from . import glr_path_static
 from .binder import copy_binder_files
@@ -27,6 +29,8 @@ from .binder import copy_binder_files
 # from .docs_resolv import embed_code_links
 from .gen_gallery import fill_mkdocs_nav, generate_gallery_md, parse_config, summarize_failing_examples
 from .utils import is_relative_to
+
+IS_PY37 = parse_version("3.7") <= parse_version(platform.python_version()) < parse_version("3.8")
 
 mkdocs_version = version.parse(mkdocs_version_str)
 is_mkdocs_14_or_greater = mkdocs_version >= version.parse("1.4")
@@ -207,7 +211,10 @@ class GalleryPlugin(BasePlugin):
                 if "toc.integrate" not in config["theme"]["features"]:
                     config["theme"]["features"].append("navigation.indexes")
 
-        extra_config_yml = """
+        # Set Python version dependent emoji logic for backward compatibility
+        mx_name = "materialx" if IS_PY37 else "material.extensions"
+
+        extra_config_yml = f"""
 markdown_extensions:
   # to declare attributes such as css classes on markdown elements. For example to change the color
   - attr_list

--- a/src/mkdocs_gallery/plugin.py
+++ b/src/mkdocs_gallery/plugin.py
@@ -224,8 +224,8 @@ markdown_extensions:
 
   # to have the download icons in the buttons
   - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:{mx_name}.emoji.twemoji
+      emoji_generator: !!python/name:{mx_name}.emoji.to_svg
 
 
 """


### PR DESCRIPTION
This Pull request updates the emoji logic for mkdocs-material, fixes #103.

 - [x] I completed the issue numbers (#xx) in the sentence above. The word "fixes" should remain in front of each issue
 - [x] My PR is tagged as draft when I'm still working on it, and I remove the draft flag when it is ready for review.
- [x] I added one or several `changelog.md` entries in the appropriate "in progress" section (not the last release one)

### b - My PR fixes some issues:

 - [x] Each issue is well-described, well-labeled, and contains reproducible code examples.
